### PR TITLE
Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This workshop builds on the [oauth workshop](https://github.com/foundersandcoders/oauth).
 
 The first readmes explain the concepts, and the later ones walk you through how to stora the
-github access token in a JSON web token.
+github access token in a JSON Web Token.
 
 Pair up and swap driver/navigator at each step during the hands on part of this workshop.
 
 ## Walkthrough
 + [Step 1 - The difference between encoding, encryption and hashing ](./Step1.md)
-+ [Step 2 - What are JSON web token and why we use them](./Step2.md)
-+ [Step 3 - The structure of JSON web tokens](./Step3.md)
++ [Step 2 - What are JSON Web Token and why we use them](./Step2.md)
++ [Step 3 - The structure of JSON Web Tokens](./Step3.md)
 + [Step 4 - JWT and hapi-auth-jwt2 example](./Step4.md)
 + [Step 5 - Checking the authentication of routes](./Step5.md)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This workshop builds on the [oauth workshop](https://github.com/foundersandcoders/oauth).
 
 The first readmes explain the concepts, and the later ones walk you through how to stora the
-github access token in a json web token.
+github access token in a JSON web token.
 
 Pair up and swap driver/navigator at each step during the hands on part of this workshop.
 

--- a/Step1.md
+++ b/Step1.md
@@ -1,6 +1,6 @@
 # Big world alert: encoding vs encryption vs hashing
 
-To understand how JSON web tokens are built, it is important to understand the difference among encryption,
+To understand how JSON web tokens are built, it is important to understand the difference between encryption,
 encoding, and hashing.
 
 ## 1. Encoding
@@ -18,36 +18,37 @@ Example:
 Examples:
 
 - **Symmetric key algorithms** use related or identical encryption keys for both encryption and decryption.
-  E.g.: Johm uses the key )'my-super-secret-key' to encrypt his secret message to James, he will be able to decrypt the message with the same key ('my-super-secret-key').
+  E.g. John uses the key 'my-super-secret-key' to encrypt his secret message to James, he will be able to decrypt the message with the same key ('my-super-secret-key').
 - **Asymmetric key algorithms** use different keys for encryption and decryption.
   - one key (the public key) is used to encrypt the message,
   - the other key (private key) can only be used to decrypt the message.
-  John can generates a public - private key pair. He uses the private key to encrypt his messages. He has to send the private key to James, so that he can encrypt the messages. The encrypted messages can only be decrypted using the private key.
+  John generates a public/private key pair.  
+  He uses the public key to encrypt his messages. He has to send the private key to James, so that James can encrypt the messages. The encrypted messages can only be decrypted using the private key.
 
 ## 3. Hashing vs Encryption
-Don't encrypt passwords. Though secure when encrypted, the **passwords can be decrypted with the encryption key**. Our program will need to save it somewhere in order to use it, so we are vulnerable to an attack stealing the encryption key and decrypting all the passwords.
+Don't encrypt passwords. Though secure when encrypted, the **passwords can be decrypted with the encryption key**. Our program will need to save it somewhere in order to use it. So we are vulnerable to attacks that steal the encryption key and decrypt all the passwords.
 
 Instead we should 'hash' passwords. Hashing is similar to encryption except that it is a one-way process and does not require a secret key. Each time we give a hash function the same input we get the same output. But we can't use the output to calculate the input. For example: 15 % 10 will always be 5. But if we have n % 10 = 5 we can't work out what n is, because there are infinite possibilities (5, 15, 25...).
 
 ## 4. Hacker attacks
 
-- dictionary attack: uses a list of  words, phrases and expressions commonly used as passwords. Each word in the list is hashed, and compared to the hashed password. If they match, the hacker found the password.
+- Dictionary attack: uses a list of  words, phrases and expressions commonly used as passwords. Each word in the list is hashed, and compared to the hashed password. If they match, the hacker finds the password.
 
-- brute force attack: tries every possible combination of characters up to a certain length. It is computationally expensive (takes a long time), but theycan always find the password. If the passwords arelong enough, it is too computationally expensive to compute them.
+- Brute force attack: tries every possible combination of characters up to a certain length. It is computationally expensive (takes a long time), but they can always find the password. If the passwords are long enough, it is too computationally expensive to compute them.
 
-- lookup tables: precompute the hashes of possible passwords and store the password-hashed password pairs in a lookup table data structure. If the impementation is good enough, hundreds of hashes can be checked per second.
+- Lookup tables: precompute the hashes of possible passwords and store the pairs (password & hashed password) in a lookup table data structure. If the implementation is good enough, hundreds of hashes can be checked per second.
 
 ## 5. Salt factors
 
-Because a hash function will always give the same output for the same input an attacker with access to a database of hashed passwords could try hashing lots of possible passwords and seeing if the hashed output matches any of the hashed passwords. Precomputed lists of hashes (called 'hash tables') exist so an attacker doesn't even need to do the computation themselves.
+A hash function will always give the same output for the same input. So, an attacker with access to a database of hashed passwords could try hashing lots of possible passwords, and seeing if the hashed output matches any of the hashed passwords. Precomputed lists of hashes (called 'hash tables') exist so an attacker doesn't even need to do the computation themselves.
 
 To defend against this we should use 'salting'. We append a unique random string (known as the 'salt') to the password before hashing it. The addition of the salt changes the output hash. Hash tables are therefore no longer useful for attackers because the hashes they contain are for passwords without any additional salt.
 
 Of course, if we are to test a user-submitted password against the one stored in the database we need to know the salt so we can add it to the submitted password before hashing. We can store the salt in clear text alongside the password in the database. It is not a problem that an attacker with access to the database could see it, because they'd need to compute the hash of every possible password plus the salt to make any use of it.
 
-The effect of salting is to greatly increase the attacker's computation requirements because for each password in the database they need to calculate the hashes of all possible passwords plus the salt until they find a match. Plus, if each salt is unique then two identical passwords will be stored as different hashes because their salts will differ.
+The effect of salting is to greatly increase the attacker's computation requirements. This is because, for each password in the database, they need to calculate the hashes of all possible passwords plus the salt until they find a match. Plus, if each salt is unique then two identical passwords will be stored as different hashes because their salts will differ.
 
-Another defensive technique is to add a 'work factor' to the hashing to make the computation harder and so slower. The aim is to make the computation seem quick to the user but slow enough (e.g. 0.5s) that trying to compute billions of possible passwords becomes unfeasibly slow even with very fast computers.
+Another defensive technique is to add a 'work factor' to the hashing to make the computation harder and therefore slower. The aim is to make the computation seem quick to the user but slow enough (e.g. 0.5s) that trying to compute billions of possible passwords becomes unfeasibly slow even with very fast computers.
 
 
 **Case 1:** To verify a hashed password without salt, you compute ```HS256(password)```, and compare
@@ -63,7 +64,7 @@ if 3 of your users have ```123456``` as its password, and you use ```HS256``` al
 |user7       | 8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92 |
 |user13      | 8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92 |
 
-As soon as a hacker finds one password in a hash table, he knows all the other.
+As soon as a hacker finds one password in a hash table, he knows all the others.
 
 **Case 2:** all three users have the same password, but you compute ```HS256(password+salt)``` to save the data
 into your database. The SALT factor is always 11.
@@ -75,7 +76,7 @@ into your database. The SALT factor is always 11.
 |user7       | 11   | f47bbcf0fa016dcc0d5a0c5b8c22e44e3ef7b59327708d9dee37905b5a95cde0 |
 |user13      | 11   | f47bbcf0fa016dcc0d5a0c5b8c22e44e3ef7b59327708d9dee37905b5a95cde0 |
 
-Following this approach, the hacker will have to bruteforce the hashes to get the passwords. It will slow him down, but as soon as one password is cracked, he knows the others too.
+Following this approach, the hacker will have to brute force the hashes to get the passwords. It will slow him down, but as soon as one password is cracked, he knows the others too.
 
 **Case 3:** all the users have the same password, but we compute ```HS256(password+random salt)```  
 
@@ -85,7 +86,7 @@ Following this approach, the hacker will have to bruteforce the hashes to get th
 |user7       |  99  | a2d54cc60a4b8c5c5f14f5bcd8fb8b4f38d8a47e9c0ed4240aa949ce3677cd0d |
 |user13      |  22  | dbea1b528e1306ab5d00a6913b091ae0d9fa5a4aa361868ebb20f8a55f957051 |
 
-Even if all your users have the same password, the hacker cannot know without bruteforce every password. 
+Even if all your users have the same password, the hacker cannot know without brute forcing every password.
 
 
 Resources:  

--- a/Step1.md
+++ b/Step1.md
@@ -88,6 +88,7 @@ Following this approach, the hacker will have to brute force the hashes to get t
 
 Even if all your users have the same password, the hacker cannot know without brute forcing every password.
 
+[Step 2 - What are JSON Web Token and why we use them](./Step2.md)
 
 Resources:  
 - [Why should i hash passwords?](https://security.stackexchange.com/questions/36833/why-should-i-hash-passwords)  
@@ -99,5 +100,3 @@ Resources:
 - [Encoding vs Encryption](http://stackoverflow.com/questions/4657416/difference-between-encoding-and-encryption)
 - [Symmetric vs Asymmetric encryption](https://www.ssl2buy.com/wiki/symmetric-vs-asymmetric-encryption-what-are-differences)
 - [hash generator](http://www.freeformatter.com/hmac-generator.html)
-
-[Step 2 - What are JSON Web Token and why we use them](./Step2.md)

--- a/Step1.md
+++ b/Step1.md
@@ -1,6 +1,6 @@
 # Big world alert: encoding vs encryption vs hashing
 
-To understand how JSON web tokens are built, it is important to understand the difference between encryption,
+To understand how JSON Web Tokens are built, it is important to understand the difference between encryption,
 encoding, and hashing.
 
 ## 1. Encoding
@@ -100,4 +100,4 @@ Resources:
 - [Symmetric vs Asymmetric encryption](https://www.ssl2buy.com/wiki/symmetric-vs-asymmetric-encryption-what-are-differences)
 - [hash generator](http://www.freeformatter.com/hmac-generator.html)
 
-[Step 2 - What are JSON web token and why we use them](./Step2.md)
+[Step 2 - What are JSON Web Token and why we use them](./Step2.md)

--- a/Step2.md
+++ b/Step2.md
@@ -1,6 +1,6 @@
-## What is a JSON web token(JWT)?
+## What is a JSON Web Token(JWT)?
 
-> A JSON web token (JWT) is a JSON object, which is a safe way to represent and transmit a set of inromation between two parties. The token is composed of a header, a payload and a signature.
+> A JSON Web Token (JWT) is a JSON object, which is a safe way to represent and transmit a set of inromation between two parties. The token is composed of a header, a payload and a signature.
 
 *(Please note that a double quoted string is  considered a valid JSON object.)*
 
@@ -8,7 +8,7 @@
 - **JWTs are self-contained** which means that the payload contains all the necessary information about the user, avoiding the need to query the database more than once.
 - JWTs are versatile and can be passed around easily. They are small, so they can be sent through **URL**, **POST parameters** or inside an **HTTP header**.
 
-## When should you use JSON web tokens?
+## When should you use JSON Web Tokens?
 
 - **Authentication**: the most common use of JWTs. After logging in, each subsequent request will contain the JWT, allowing the user to access the routes and services that are alowed with that token.
 
@@ -32,4 +32,4 @@ The authentication flow:
 - [JWT signing algorithms overview](https://auth0.com/blog/json-web-token-signing-algorithms-overview/)  
 - [HWT the right way](https://stormpath.com/blog/jwt-the-right-way)  
 
-[Step 3 - The structure of JSON web tokens](./Step3.md)
+[Step 3 - The structure of JSON Web Tokens](./Step3.md)

--- a/Step2.md
+++ b/Step2.md
@@ -4,15 +4,15 @@
 
 *(Please note that a double quoted string is  considered a valid JSON object.)*
 
-- JWT are used across several programming languages .NET, Python, Node.js, Java, PHP, Ruby, Go, JavaScript, and Haskell.
-- **JWTs are self-contained** which means that the payload contains all the necessary information about the user, avoiding to query the database more than once.
+- JWTs are used across several programming languages .NET, Python, Node.js, Java, PHP, Ruby, Go, JavaScript, and Haskell.
+- **JWTs are self-contained** which means that the payload contains all the necessary information about the user, avoiding the need to query the database more than once.
 - JWTs are versatile and can be passed around easily. They are small, so they can be sent through **URL**, **POST parameters** or inside an **HTTP header**.
 
 ## When should you use JSON web tokens?
 
 - **Authentication**: the most common use of JWTs. After logging in, each subsequent request will contain the JWT, allowing the user to access the routes and services that are alowed with that token.
 
-- **Information exchange**: JWTs can be used to securely transmit information between parties, since they are signed e.g.: using public/private key pairs. The signature is determined based on both the header and the payload using a hashing algorithm, so you can check that the content hasn't been tampered with.
+- **Information exchange**: JWTs can be used to securely transmit information between parties, since they are signed e.g. using public/private key pairs. The signature is determined based on both the header and the payload using a hashing algorithm, so you can check that the content hasn't been tampered with.
 
 ## How do JWTs work?
 ![JWTs explained](./imgs/jwts_explained.png)
@@ -21,10 +21,10 @@
 - application server: the website you make.
 
 The authentication flow:
-- the user signs into the authentication server's login system (e.g.: your github username and password)
+- the user signs into the authentication server's login system (e.g. your github username and password)
 - if the authentication is successful, the authentication server creates a JWT, and sends it to the user.
 - if the user makes an API call to the authentication server, the JWT is sent along with the API call (in the header or in a cookie).
-- the applicaton server is able to verify that the JWT was issued by the authentication serrver, hence the API call is from an autheenticated user.
+- the application server is able to verify that the JWT was issued by the authentication server, hence the API call is from an authenticated user.
 
 
 ## Resources

--- a/Step2.md
+++ b/Step2.md
@@ -26,10 +26,9 @@ The authentication flow:
 - if the user makes an API call to the authentication server, the JWT is sent along with the API call (in the header or in a cookie).
 - the application server is able to verify that the JWT was issued by the authentication server, hence the API call is from an authenticated user.
 
+[Step 3 - The structure of JSON Web Tokens](./Step3.md)
 
 ## Resources
 - [medium article on understanding JWTs](https://medium.com/vandium-software/5-easy-steps-to-understanding-json-web-tokens-jwt-1164c0adfcec#.z80hda8ty)  
 - [JWT signing algorithms overview](https://auth0.com/blog/json-web-token-signing-algorithms-overview/)  
 - [HWT the right way](https://stormpath.com/blog/jwt-the-right-way)  
-
-[Step 3 - The structure of JSON Web Tokens](./Step3.md)

--- a/Step3.md
+++ b/Step3.md
@@ -62,10 +62,10 @@ You take the encoded header and the encoded payload. Using these and the algorit
 The snippet above generates the third part of the JWT, which is the signature held by the server that is used to verify existing tokens and sign new ones: `03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773`
 
 Combining all three parts above, the JWT looks like this:
-`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773
+`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773`
+
+[Step 4 - JWT and hapi-auth-jwt2 example](./Step4.md)
 
 Resources:
 - [JWT decoder](https://jwt.io/)
 - [JWTs](https://jwt.io/introduction/)
-
-[Step 4 - JWT and hapi-auth-jwt2 example](./Step4.md)

--- a/Step3.md
+++ b/Step3.md
@@ -6,7 +6,7 @@ A JSON web token consists of three strings separated by dots.
 ![JWT structure](./imgs/jwt_structure.png)
 
 ### 1) Create header (algorithm and token type) using encoding
-- an encoded representation of a simple JavaScript oject
+- an encoded representation of a simple JavaScript object
 - tells how the JWT signature should be computed.
 
 Example (JSON object - remove comments before using)
@@ -21,12 +21,12 @@ Example (JSON object - remove comments before using)
 ```
 *Note*: In order for the transmitted information to be verified, it has to be digitally signed. JWTs can be signed using a secret (with HMAC algorithm) or a public/private key pair using RSA.
 
-If you then `base64UrlEncode` (this is not a built-in JavaScript function) the header json object, you get the string `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9` for the first part of the JWT.
+If you then `base64UrlEncode` (this is not a built-in JavaScript function) the header JSON object, you get the string `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9` for the first part of the JWT.
 
 ### 2) Create payload (bulk of information) using encoding
 
 - encoded
-- the length of the payload is proportional to the amount of data you store in the token
+- the length of the payload is proportional to the amount of data you store in the token  
 It can contain reserved, public and private claims (i.e. statements about different entities such as the user and additional metadata).  
 
 *Example (JSON object - remove comments before using)*
@@ -48,9 +48,9 @@ It can contain reserved, public and private claims (i.e. statements about differ
 If you then `base64UrlEncode` (this is not a built-in JavaScript function) the payload json object, you get the string `eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0` for the second part of the JWT.
 
 ### 3) Create signature using encryption and encoding
-- it is created based on the header and payload
-- it is encoded and signed
-You take the encoded header, the encoded payload and using the algorithm specified in the header, you generate a secret, encode all components and sign the JWT.
+- created based on the header and payload
+- encoded and signed  
+You take the encoded header and the encoded payload. Using these and the algorithm specified in the header, you: generate a secret, encode all components and sign the JWT.
 
 *Example (JSON object - remove comments before using)*   
 ```javascript
@@ -59,7 +59,7 @@ You take the encoded header, the encoded payload and using the algorithm specifi
   base64UrlEncode(payload),
   'secret')
 ```
-The snippet above generates the third part of the JWT, which is the signature held by the server to verify existing tokens and sign new ones: `03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773`
+The snippet above generates the third part of the JWT, which is the signature held by the server that is used to verify existing tokens and sign new ones: `03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773`
 
 Combining all three parts above, the JWT looks like this:
 `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773

--- a/Step3.md
+++ b/Step3.md
@@ -2,7 +2,7 @@
 
 ## JWTs under the hood
 
-A JSON web token consists of three strings separated by dots.
+A JSON Web Token consists of three strings separated by dots.
 ![JWT structure](./imgs/jwt_structure.png)
 
 ### 1) Create header (algorithm and token type) using encoding

--- a/Step4.md
+++ b/Step4.md
@@ -142,10 +142,8 @@ function(token, request, callback){
   }
 };
 ```
+[Step 5 - Checking the authentication of routes](./Step5.md)
 
 Resources:
 - [hapi-auth-jwt2](https://github.com/dwyl/hapi-auth-jwt2)
 - [hapi-auth-jwt2](https://www.npmjs.com/package/hapi-auth-jwt2)
-
-
-[Step 5 - Checking the authentication of routes](./Step5.md)

--- a/Step4.md
+++ b/Step4.md
@@ -81,7 +81,6 @@ jwt.sign(payload, secret, options, (err, token) => {
   //  console.log('decoded token',jwt.verify(token, process.env.SECRET)); // check that you can decode it
   let config = {
     path: '/',  // the token is valid for every path starting with /
-    isHttpOnly: false,
     isSecure: process.env.NODE_ENV === 'PRODUCTION'
   }
 

--- a/Step4.md
+++ b/Step4.md
@@ -4,7 +4,7 @@
 The hands on part of this workshop builds on the [OAuth workshop](https://github.com/foundersandcoders/oauth-workshop) from yesterday.  
 
 
-The workshop uses the ```hapi-auth-jwt2``` and the ```jsonwebtoken``` npm packages. These packages handle many things under the hood. E.g. Encoding and signing the different parts of the json web token is hidden form us.
+The workshop uses the ```hapi-auth-jwt2``` and the ```jsonwebtoken``` npm packages. These packages handle many things under the hood. E.g. Encoding and signing the different parts of the JSON Web Token is hidden form us.
 
 ### Step 1 - Query the github API
 
@@ -68,7 +68,7 @@ General:
 jwt.sign(payload,secret,options,callback);
 ```
 
-This function build the JSON web token. Please bare in mind that JWTs are not encrypted. They are encoded and signed. If the aim is not to expose the token to the user, a JWT in itself won't protect it.
+This function build the JSON Web Token. Please bare in mind that JWTs are not encrypted. They are encoded and signed. If the aim is not to expose the token to the user, a JWT in itself won't protect it.
 
 - the simplest approach is to set the JWT in a cookie, it is an acceptable approach, in this way the client won't be able to read it. (This is what we do in this workshop.)
 - store the cookie on the server

--- a/Step4.md
+++ b/Step4.md
@@ -1,17 +1,16 @@
 ## JWT workshop
 
 
-The hands on part of this workshop builds on the [oAuth workshop](https://github.com/foundersandcoders/oauth) on Monday.  
+The hands on part of this workshop builds on the [OAuth workshop](https://github.com/foundersandcoders/oauth-workshop) from yesterday.  
 
 
-The workshop uses the ```hapi-auth-jwt2``` and the ```jsonwebtoken``` npm packages. These packages handle many things under the hood. E.g.: Encoding and signing the different parts of the json web token is hidden form our eyes.
+The workshop uses the ```hapi-auth-jwt2``` and the ```jsonwebtoken``` npm packages. These packages handle many things under the hood. E.g. Encoding and signing the different parts of the json web token is hidden form us.
 
-### Step 1
+### Step 1 - Query the github API
 
- In Step 4 (Monday's) workshop we send a POST request to the github API, and the response's body
-contains the access token. This is the starting point of this workshop.
+In [Step 4](https://github.com/foundersandcoders/oauth-workshop/blob/master/step4.md) of Day 1's OAuth workshop, we sent a POST request to the github API, and the body of the response contained the access token. This is the starting point of this workshop.
 
-If we want to authenticate or user with github, get their details (e.g.: name, avatar, user id).
+If we want to authenticate our user with github, we need to get their details (e.g. name, avatar, user id).  
 In a real life scenario, we might want to save their details to a database (it is not part of this workshop).
 
 The next step is that we send a GET request to the github API, in order to get these details (that we later want to save in a JSON Web Token).
@@ -28,9 +27,9 @@ Hints:
 ```
 - get request:  
 ```
-  Request.get({url:url, headers:header}, function (error, response, body) {...}
+  Request.get({url:url, headers:header}, function (error, response, body) {...})
   ```
-### Step 2  Build the JSON Web Token!
+### Step 2 - Build the JSON Web Token!
 
 Install the npm packages we use.
 
@@ -39,7 +38,7 @@ npm install --save jsonwebtoken
 ```
 
 - secret: used for signing the token, it can be  whater you want, save it as an environment variable.
-- options object: include the expiration data and the subject.
+- options object: include the expiration date and the subject.
 ```
 let options = {
         'expiresIn': Date.now() + 24 * 60 * 60 * 1000,
@@ -67,9 +66,9 @@ General:
 jwt.sign(payload,secret,options,callback);
 ```
 
-This function build the JSON web token. Please bear in mind that JWTs don't encrypt. They are encoded and signed. If the aim is not to expose the token to the user, a JWT in itself won't protect it.
+This function build the JSON web token. Please bare in mind that JWTs are not encrypted. They are encoded and signed. If the aim is not to expose the token to the user, a JWT in itself won't protect it.
 
-- the simplest approach is to set the JST in a cookie, it is an acceptable approach, in this way the client won1t be able to read it. (This is what we do in this workshop.)
+- the simplest approach is to set the JWT in a cookie, it is an acceptable approach, in this way the client won't be able to read it. (This is what we do in this workshop.)
 - store the cookie on the server
 - encrypt the cookie.
 
@@ -98,7 +97,7 @@ const secure={
 }
 ```
 
-## Step 3 register the authentication strategy in server.js
+### Step 3 - Register the authentication strategy in server.js
 
 
 ```
@@ -113,10 +112,10 @@ server.auth.strategy('jwt', 'jwt',
   });
 ```
 
-## STEP 4  Validate function
+### Step 4 - Validate function
 Note: the token is automatically decoded!!
 
-- build a dummy users object,(normally you would have a users database, and you would query the database)
+- build a dummy users object (normally you would have a users database, and you would query the database)
 
 ```
 var people = { // our "users database", use your github details here

--- a/Step4.md
+++ b/Step4.md
@@ -19,27 +19,27 @@ Hints:
 - use the request npm module
 - request url: `https://api.github.com/user`;
 - header:  
- ```
+ ```javascript
   let header = {
             'User-Agent': 'oauth_github_jwt',
             Authorization: `token ${token.access_token}`
           };
 ```
 - get request:  
-```
+```javascript
   Request.get({url:url, headers:header}, function (error, response, body) {...})
   ```
 ### Step 2 - Build the JSON Web Token!
 
 Install the npm packages we use.
 
-```
+```shell
 npm install --save jsonwebtoken
 ```
 
 - secret: used for signing the token, it can be  whater you want, save it as an environment variable.
 - options object: include the expiration date and the subject.
-```
+```javascript
 let options = {
         'expiresIn': Date.now() + 24 * 60 * 60 * 1000,
         'subject': 'github-data'
@@ -48,7 +48,7 @@ let options = {
 - Create payload
 It should contain the user details (from the get request to the github API) and the access token.
 
-```
+```javascript
 let payload = {
     'user': {
         'username': body.login,
@@ -62,7 +62,7 @@ let payload = {
   -  Create signature
 
 General:
-```
+```javascript
 jwt.sign(payload,secret,options,callback);
 ```
 
@@ -73,7 +73,7 @@ This function build the JSON web token. Please bare in mind that JWTs are not en
 - encrypt the cookie.
 
 For us now:
-```
+```javascript
 jwt.sign(payload,secret,options, (err,token) => {
 //  console.log(token);
 //  console.log('decoded token',jwt.verify(token, process.env.SECRET)); // check that you can decode it
@@ -88,7 +88,7 @@ reply
 ```
 
 Configure the auth strategy for the new route:
-```
+```javascript
 const secure={
   method: 'GET',
   path: '/secure',
@@ -100,11 +100,11 @@ const secure={
 ### Step 3 - Register the authentication strategy in server.js
 
 
-```
+```shell
 npm install --save hapi-auth-jwt2
 ```
 
-```
+```javascript
 server.auth.strategy('jwt', 'jwt',
   { key: process.env.SECRET,
     validateFunc: validate,
@@ -117,7 +117,7 @@ Note: the token is automatically decoded!!
 
 - build a dummy users object (normally you would have a users database, and you would query the database)
 
-```
+```javascript
 var people = { // our "users database", use your github details here
     1: {
       id: 1,
@@ -126,7 +126,7 @@ var people = { // our "users database", use your github details here
 };
 ```
 
-```
+```javascript
 function(token, request,callback){
   console.log(token.id); //deccoded token, it automaitcally decodes it
   if (!people[token.id]) {

--- a/Step5.md
+++ b/Step5.md
@@ -3,18 +3,18 @@ After you managed to save the token.
 
 ## Check the routes with curl
 
-1, The home route dooesn't require a token
-```
+The home route doesn't require a token
+```shell
 curl -v http://localhost:3000/
 ```
 
 ## Secure route requires a token
 Try to access the /secure route without providing a token
 
-```
+```shell
 curl -v http://localhost:3000/secure
 ```
 
-```
+```shell
 {"statusCode":401,"error":"Unauthorized","message":"Missing authentication"}
 ```

--- a/mentor_notes/Questions.md
+++ b/mentor_notes/Questions.md
@@ -33,7 +33,7 @@ Lookup tables are only effective because each password is hahed the same way. If
 
   - The salt doesn't need to be a secret!! Just by using randomized hashes lookup tables will become ineffective.
 
-### What are JSON web token and why we use them
+### What are JSON Web Token and why we use them
 
 #### Question 1. When and why we use JWTs?
   - safe way to represent and transmit a set of inromation between two parties
@@ -59,7 +59,7 @@ Lookup tables are only effective because each password is hahed the same way. If
 
 ![JSON Web Token flow](../imgs/jwts_explained.png)
 
-### The structure of JSON web tokens
+### The structure of JSON Web Tokens
 
 #### Question 1. Name the three parts of a JWT? Which parts are encoded,signed, or encrypted?
   - header -- encoded

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fac10_jwt_workshop",
   "version": "1.0.0",
-  "description": "## What is a JSON web token(JWT)?",
+  "description": "## What is a JSON Web Token(JWT)?",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
+ Fixes typos
+ Fixes line formatting (add 2 spaces at the end of a line before pressing enter)
+ Add syntax highlighting to code blocks
+ Fix indentation on code blocks
+ Make capitalisation & headings consistent
+ Remove `httpOnly = false` from `step4.md` - this is not good practice & no longer necessary [now that we get our students to connection to HTTPS](https://github.com/foundersandcoders/oauth-workshop/blob/master/step2.md#step-2---set-up-your-ssl-certificates)

Fixes #8 (step 1)
Fixes #9 (step 2)
Fixes #10 (step 3)
Fixes #11 (step 4)
Fixes #12 (step 5)

+ Move links to the next step of the workshop above the list of resources

Fixes #13